### PR TITLE
py4J 0.10.9.3 for spark 3.2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ ADD spark-env.sh $SPARK_HOME/conf
 ADD entrypoint.sh /opt/entrypoint.sh
 RUN chmod +x /opt/entrypoint.sh $SPARK_HOME/conf/spark-env.sh
 
-ENV PYTHONPATH="$SPARK_HOME/python:$SPARK_HOME/python/lib/py4j-0.10.9.2-src.zip"
+ENV PYTHONPATH="$SPARK_HOME/python:$SPARK_HOME/python/lib/py4j-0.10.9.3-src.zip"
 ENV SPARK_OPTS --driver-java-options=-Xms1024M --driver-java-options=-Xmx4096M
 ENV JAVA_HOME "/usr/lib/jvm/java-11-openjdk-amd64"
 ENV HADOOP_OPTIONAL_TOOLS "hadoop-aws"


### PR DESCRIPTION
py4j vesion change.
Could be handle automatically by https://spark.apache.org/docs/latest/api/python/getting_started/install.html#manually-downloading
Need a decent docker environment to make that